### PR TITLE
Add "uniform integers" exercise

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint --ext .ts .",
     "lint:fix": "eslint --fix --ext .ts .",
-    "format": "prettier --write '**/*.{ts,json,yml,yaml,md}'",
+    "format": "prettier --write '**/**/*.{ts,json,yml,yaml,md}'",
     "ts-check": "tsc --pretty"
   },
   "repository": {

--- a/src/exercises/uniform-integers/README.md
+++ b/src/exercises/uniform-integers/README.md
@@ -1,0 +1,53 @@
+# Uniform Integers
+
+A positive integer is considered uniform if all of its digits are equal. For example, 222222 is uniform, while 223223 is not.
+
+Given two positive integers AA and BB, determine the number of uniform integers between AA and BB, inclusive.
+
+Please take care to write a solution which runs within the time limit.
+
+## Constraints
+
+```
+1 ≤ A ≤ B ≤ 10^12
+```
+## Sample test case 1
+
+```
+A = 75
+B = 300
+```
+
+```
+Expected Return Value = 5
+```
+
+## Sample test case 2
+
+```
+A = 1
+B = 9
+```
+
+```
+Expected Return Value = 1
+```
+
+## Sample test case 3
+
+```
+A = 999999999999
+B = 999999999999
+```
+
+```
+Expected Return Value = 1
+```
+
+## Sample Explanation
+
+In the first case, the uniform integers between 7575 and 300300 are 7777, 8888, 9999, 111111, and 222222.
+
+In the second case, all 99 single-digit integers between 11 and 99 (inclusive) are uniform.
+
+In the third case, the single integer under consideration (999{,}999{,}999{,}999999,999,999,999) is uniform.

--- a/src/exercises/uniform-integers/README.md
+++ b/src/exercises/uniform-integers/README.md
@@ -11,6 +11,7 @@ Given two positive integers A and B, determine the number of uniform integers be
 ```
 
 where N is an arbitrary MAX_INTEGER suported by the runtime.
+
 ## Sample test case 1
 
 ```

--- a/src/exercises/uniform-integers/README.md
+++ b/src/exercises/uniform-integers/README.md
@@ -1,16 +1,16 @@
 # Uniform Integers
 
-A positive integer is considered uniform if all of its digits are equal. For example, 222222 is uniform, while 223223 is not.
+A positive integer is considered uniform if all of its digits are equal. For example, 222222 is uniform as well as 3, while 223223 or 31 are not.
 
-Given two positive integers AA and BB, determine the number of uniform integers between AA and BB, inclusive.
-
-Please take care to write a solution which runs within the time limit.
+Given two positive integers A and B, determine the number of uniform integers between them (A and B inclusive).
 
 ## Constraints
 
 ```
-1 ≤ A ≤ B ≤ 10^12
+1 <= A <= B <= N
 ```
+
+where N is an arbitrary MAX_INTEGER suported by the runtime.
 ## Sample test case 1
 
 ```
@@ -22,16 +22,20 @@ B = 300
 Expected Return Value = 5
 ```
 
+The uniform integers between 7575 and 300300 are 7777, 8888, 9999, 111111, and 222222.
+
 ## Sample test case 2
 
 ```
-A = 1
-B = 9
+A = 11
+B = 99
 ```
 
 ```
-Expected Return Value = 1
+Expected Return Value = 9
 ```
+
+All numbers multiple of 11 are uniform.
 
 ## Sample test case 3
 
@@ -44,10 +48,30 @@ B = 999999999999
 Expected Return Value = 1
 ```
 
-## Sample Explanation
+The single integer under consideration `999.999.999.999` is the only number in the interval and happens to be uniform.
 
-In the first case, the uniform integers between 7575 and 300300 are 7777, 8888, 9999, 111111, and 222222.
+## Sample test case 4
 
-In the second case, all 99 single-digit integers between 11 and 99 (inclusive) are uniform.
+```
+A = 2
+B = 8
+```
 
-In the third case, the single integer under consideration (999{,}999{,}999{,}999999,999,999,999) is uniform.
+```
+Expected Return Value = 7
+```
+
+All single-digit numbers are uniform, and there are 7 numbers between A and B included.
+
+## Sample test case 5
+
+```
+A = 7
+B = 11
+```
+
+```
+Expected Return Value = 4
+```
+
+Same as test case 4 where all single-digit numbers are uniform, plus the number 11 itself.

--- a/src/exercises/uniform-integers/index.ts
+++ b/src/exercises/uniform-integers/index.ts
@@ -10,7 +10,7 @@ function init(A) {
  * @param {number} B
  * @return {number}
  */
-function getUniformIntegerCountInInterval(A, B) {
+export function getUniformIntegerCountInInterval(A, B) {
   // if A and B are less than or equal to 9
   if (B <= 9) {
     return B - A + 1;

--- a/src/exercises/uniform-integers/index.ts
+++ b/src/exercises/uniform-integers/index.ts
@@ -1,0 +1,59 @@
+function init(A) {
+  const tokens = `${A}`.split('');
+  return {
+    digit: Number(tokens[0]),
+    numberPositions: tokens.length
+  }
+}
+/**
+ * @param {number} A
+ * @param {number} B
+ * @return {number}
+ */
+function getUniformIntegerCountInInterval(A, B) {
+  // if A and B are less than or equal to 9
+  if (B <= 9) {
+    return B - A + 1;
+  }
+
+  // if only A is less than 10 add the diff in the counter
+  let counter = 0
+  const diff = 10 - A;
+
+  if (diff > 0) {
+    counter = diff;
+  }
+
+  // build the first unifor number picking the left-most digit
+  let { digit, numberPositions } = init(A);
+  let number = `${digit}`.repeat(numberPositions);
+
+  // if this number is less than A select the next uniform number
+  if (Number(number) < A) {
+    if (digit === 9) {
+      digit = 1;
+      numberPositions++
+    } else {
+      digit++
+    }
+  }
+
+  // while the number is less or equal to B
+  while (Number(number) <= B) {
+    // increase the counter
+    counter++;
+
+    // find the next uniform number
+    if (digit === 9) {
+      digit = 1;
+      numberPositions++
+    } else {
+      digit++
+    }
+
+    number = `${digit}`.repeat(numberPositions);
+  }
+
+
+  return counter;
+}

--- a/src/exercises/uniform-integers/index.ts
+++ b/src/exercises/uniform-integers/index.ts
@@ -1,59 +1,107 @@
-function init(A) {
-  const tokens = `${A}`.split('');
-  return {
-    digit: Number(tokens[0]),
-    numberPositions: tokens.length
-  }
+/**
+ * In case B > 9, the end of the interval is not a single-digit, but A can still be.
+ *
+ * In that case, we want to calculate 10 - A
+ *
+ * If the difference is negative or equal to zero, it means that also A isn't a single-digit number
+ * and we initialise the counter with 0.
+ *
+ * If the difference is a positive number, A is a single-digit number and we want to calculate how many
+ * of them there are between A and 9 and initialise the counter with this.
+ *
+ * @param A the beginning of the interval
+ * @returns the counter
+ */
+function initTheCounter(A: number): number {
+  const diff = 10 - A;
+
+  return diff > 0 ? diff : 0;
 }
+
+/**
+ * Returns the first uniform number that is greater than or equal to A.
+ *
+ * @param A the initial number of the interval
+ * @returns the first uniform number N >= A
+ */
+function findTheFirstUniformInteger(A: number) {
+  const tokens = `${A}`.split('');
+
+  // gets the left-most digit of the number and the number of digits the number is composed of
+  let leftMostDigit = Number(tokens[0]);
+  const numberOfDigits = tokens.length;
+
+  // builds the uniform integer
+  let uniformInteger = `${leftMostDigit}`.repeat(numberOfDigits);
+
+  // if this number is less than A, pick the next uniform number
+
+  if (Number(uniformInteger) < A) {
+    // we don't need to check for the case where leftMostDigit === 9
+    // because any uniform integer with a left-most digit equal to 9 will never be
+    // strictly less than A
+
+    leftMostDigit += 1;
+
+    uniformInteger = `${leftMostDigit}`.repeat(numberOfDigits);
+  }
+
+  return { uniformInteger, leftMostDigit, numberOfDigits };
+}
+
 /**
  * @param {number} A
  * @param {number} B
  * @return {number}
  */
-export function getUniformIntegerCountInInterval(A, B) {
-  // if A and B are less than or equal to 9
+export function getUniformIntegerCountInInterval(A: number, B: number) {
+  /*
+   * Input check
+   */
+
+  if (!Number.isInteger(A) || !Number.isInteger(B))
+    throw new Error('The two numbers in input must be integers');
+
+  if (A > B || A <= 0) return 0;
+
+  /*
+   * Given 1 <= A <= B
+   *
+   * if B <= 9 then A <= 9
+   *
+   * This means that both ends of the intrval are single-digit numbers
+   * and we can return the difference + 1 as a result
+   */
+
   if (B <= 9) {
     return B - A + 1;
   }
 
-  // if only A is less than 10 add the diff in the counter
-  let counter = 0
-  const diff = 10 - A;
+  let counter = initTheCounter(A);
 
-  if (diff > 0) {
-    counter = diff;
+  let startInterval = A;
+
+  if (counter > 0) {
+    startInterval = 10;
   }
 
-  // build the first unifor number picking the left-most digit
-  let { digit, numberPositions } = init(A);
-  let number = `${digit}`.repeat(numberPositions);
-
-  // if this number is less than A select the next uniform number
-  if (Number(number) < A) {
-    if (digit === 9) {
-      digit = 1;
-      numberPositions++
-    } else {
-      digit++
-    }
-  }
+  let { uniformInteger, leftMostDigit, numberOfDigits } = findTheFirstUniformInteger(startInterval);
 
   // while the number is less or equal to B
-  while (Number(number) <= B) {
+  while (Number(uniformInteger) <= B) {
     // increase the counter
-    counter++;
+    counter += 1;
 
     // find the next uniform number
-    if (digit === 9) {
-      digit = 1;
-      numberPositions++
+    if (leftMostDigit === 9) {
+      leftMostDigit = 1;
+      numberOfDigits += 1;
     } else {
-      digit++
+      leftMostDigit += 1;
     }
 
-    number = `${digit}`.repeat(numberPositions);
+    uniformInteger = `${leftMostDigit}`.repeat(numberOfDigits);
   }
-
 
   return counter;
 }

--- a/test/exercises/uniform-integers/index.test.ts
+++ b/test/exercises/uniform-integers/index.test.ts
@@ -1,0 +1,82 @@
+import { getUniformIntegerCountInInterval } from 'src/exercises/uniform-integers';
+
+const parameters = [
+  {
+    start: 75,
+    end: 300,
+    expected: 5,
+  },
+  {
+    start: 11,
+    end: 99,
+    expected: 9,
+  },
+  {
+    start: 999999999999,
+    end: 999999999999,
+    expected: 1,
+  },
+  {
+    start: 2,
+    end: 8,
+    expected: 7,
+  },
+  {
+    start: 7,
+    end: 11,
+    expected: 4,
+  },
+  {
+    start: 2,
+    end: 2,
+    expected: 1,
+  },
+  {
+    start: 10,
+    end: 11,
+    expected: 1,
+  },
+  {
+    start: 55,
+    end: 11,
+    expected: 0,
+  },
+  {
+    start: 99,
+    end: 459,
+    expected: 5,
+  },
+  {
+    start: 79,
+    end: 311,
+    expected: 4,
+  },
+  {
+    start: 0,
+    end: 1,
+    expected: 0,
+  },
+  {
+    start: -3,
+    end: 0,
+    expected: 0,
+  },
+  {
+    start: 3.2,
+    end: 11,
+    isException: true,
+  },
+];
+
+test.each(parameters)(
+  'rotationalCipher("$start", $end) => $expected',
+  ({ start, end, isException, expected }) => {
+    if (isException) {
+      expect(() => getUniformIntegerCountInInterval(start, end)).toThrow(
+        'The two numbers in input must be integers'
+      );
+    } else {
+      expect(getUniformIntegerCountInInterval(start, end)).toBe(expected);
+    }
+  }
+);


### PR DESCRIPTION
# Exercise

A positive integer is considered uniform if all of its digits are equal. For example, 222222 is uniform as well as 3, while 223223 or 31 are not.

Given two positive integers A and B, determine the number of uniform integers between them (A and B inclusive).

# Changelog

Add exercise resolution and testing.